### PR TITLE
MERGE: Fix build fedora

### DIFF
--- a/frontend/cmake/os-linux.cmake
+++ b/frontend/cmake/os-linux.cmake
@@ -3,7 +3,8 @@ target_compile_definitions(
   obs-studio
   PRIVATE OBS_INSTALL_PREFIX="${OBS_INSTALL_PREFIX}" $<$<BOOL:${ENABLE_PORTABLE_CONFIG}>:ENABLE_PORTABLE_CONFIG>
 )
-target_link_libraries(obs-studio PRIVATE Qt::GuiPrivate Qt::DBus)
+find_package(Qt6 REQUIRED COMPONENTS GuiPrivate)
+target_link_libraries(obs-studio PRIVATE Qt6::GuiPrivate Qt::DBus)
 
 find_package(Libpci REQUIRED)
 target_link_libraries(obs-studio PRIVATE Libpci::pci)

--- a/frontend/cmake/os-linux.cmake
+++ b/frontend/cmake/os-linux.cmake
@@ -3,8 +3,15 @@ target_compile_definitions(
   obs-studio
   PRIVATE OBS_INSTALL_PREFIX="${OBS_INSTALL_PREFIX}" $<$<BOOL:${ENABLE_PORTABLE_CONFIG}>:ENABLE_PORTABLE_CONFIG>
 )
-find_package(Qt6 REQUIRED COMPONENTS GuiPrivate)
-target_link_libraries(obs-studio PRIVATE Qt6::GuiPrivate Qt::DBus)
+
+find_package(Qt6 COMPONENTS Gui REQUIRED)
+if(Qt6_VERSION VERSION_GREATER_EQUAL "6.10.0")
+  find_package(Qt6 REQUIRED COMPONENTS GuiPrivate)
+  target_link_libraries(obs-studio PRIVATE Qt6::GuiPrivate Qt::DBus)
+else()
+  target_link_libraries(obs-studio PRIVATE Qt::GuiPrivate Qt::DBus)
+endif()
+
 
 find_package(Libpci REQUIRED)
 target_link_libraries(obs-studio PRIVATE Libpci::pci)


### PR DESCRIPTION
Due to an update to Qt libraries, i was not able to compile after recent updates on Fedora 42.

This fixes the issue while maintaining compatibility with older versions.